### PR TITLE
Switch to standard __VA_ARGS__.

### DIFF
--- a/tlsf/src/tlsf.c
+++ b/tlsf/src/tlsf.c
@@ -174,8 +174,8 @@ extern "C"
 
 #ifdef USE_PRINTF
 #include <stdio.h>
-# define PRINT_MSG(fmt, ...) printf(fmt, ## __VA_ARGS__)
-# define ERROR_MSG(fmt, ...) printf(fmt, ## __VA_ARGS__)
+# define PRINT_MSG(...) printf(__VA_ARGS__)
+# define ERROR_MSG(...) printf(__VA_ARGS__)
 #else
 # if !defined(PRINT_MSG)
 #  define PRINT_MSG(fmt, ...)


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Building with clang shows the following error:

```
token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
```

But we can actually simplify this and just use __VA_ARGS__.  Do so, which will get rid of the warning under clang and should still work elsewhere.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13562)](http://ci.ros2.org/job/ci_linux/13562/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8454)](http://ci.ros2.org/job/ci_linux-aarch64/8454/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11284)](http://ci.ros2.org/job/ci_osx/11284/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13625)](http://ci.ros2.org/job/ci_windows/13625/)
* Linux clang [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13563)](http://ci.ros2.org/job/ci_linux/13563/)
