### PR TITLE
Install headers to include/${PROJECT_NAME}

### DIFF
--- a/tlsf/CMakeLists.txt
+++ b/tlsf/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 add_library(${PROJECT_NAME} STATIC src/tlsf.c src/target.h include/tlsf/tlsf.h)
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include/tlsf>"
-  "$<INSTALL_INTERFACE:include>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 set_target_properties(${PROJECT_NAME} PROPERTIES C_VISIBILITY_PRESET hidden)
 
 ament_export_targets(export_${PROJECT_NAME})
@@ -34,7 +34,7 @@ ament_export_targets(export_${PROJECT_NAME})
 ament_package()
 
 install(DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(


### PR DESCRIPTION
Part of https://github.com/ros2/ros2/issues/1150 - this installs headers to a unique include directory to prevent include directory search order issues when overriding packages from a merged workspace.